### PR TITLE
Enable Basic file storage for VirtualSamples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Hotifix mimemagic
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'

--- a/app/controllers/virtual_samples_controller.rb
+++ b/app/controllers/virtual_samples_controller.rb
@@ -69,7 +69,7 @@ class VirtualSamplesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def virtual_sample_params
-      params.require(:virtual_sample).permit(:project_id, :video_link)
+      params.require(:virtual_sample).permit(:project_id, :video_link, :icon_image)
     end
 
     def get_project

--- a/app/controllers/virtual_samples_controller.rb
+++ b/app/controllers/virtual_samples_controller.rb
@@ -26,6 +26,7 @@ class VirtualSamplesController < ApplicationController
   # POST /virtual_samples.json
   def create
     @virtual_sample = @project.build_virtual_sample(virtual_sample_params)
+    @virtual_sample.images.attach(params[:virtual_sample][:images])
     respond_to do |format|
       if @virtual_sample.save
         format.html { redirect_to project_virtual_sample_path, notice: 'Virtual sample was successfully created.' }
@@ -69,7 +70,7 @@ class VirtualSamplesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def virtual_sample_params
-      params.require(:virtual_sample).permit(:project_id, :video_link, :icon_image)
+      params.require(:virtual_sample).permit(:project_id, :video_link, :icon_image, :about_file)
     end
 
     def get_project

--- a/app/models/virtual_sample.rb
+++ b/app/models/virtual_sample.rb
@@ -1,3 +1,4 @@
 class VirtualSample < ApplicationRecord
-  belongs_to :project  
+  belongs_to :project 
+  has_one_attached :icon_image, :dependent => :destroy
 end

--- a/app/models/virtual_sample.rb
+++ b/app/models/virtual_sample.rb
@@ -1,4 +1,6 @@
 class VirtualSample < ApplicationRecord
   belongs_to :project 
   has_one_attached :icon_image, :dependent => :destroy
+  has_one_attached :about_file, :dependent => :destroy
+  has_many_attached :images, :dependent => :destroy
 end

--- a/app/views/virtual_samples/_form.html.erb
+++ b/app/views/virtual_samples/_form.html.erb
@@ -12,12 +12,21 @@
   <% end %>
 
   <div class="col-sm-4">
-      <div class="form-group row">
-        <%= form.label :video_link, "Link", :class => "col-sm-6 col-form-label" %>
-        <div class="col-sm-6">
-          <%= form.text_field :video_link, min:0, max: 2, :class => "form-control" %>
-        </div>
+    <div class="form-group row">
+      <%= form.label :icon_image, "Imagen de icono", :class => "col-sm-6 col-form-label" %>
+      <div class="col-sm-6">
+        <%= form.file_field :icon_image %>
       </div>
+    </div>
+  </div>
+
+  <div class="col-sm-4">
+    <div class="form-group row">
+      <%= form.label :video_link, "Link", :class => "col-sm-6 col-form-label" %>
+      <div class="col-sm-6">
+        <%= form.text_field :video_link, min:0, max: 2, :class => "form-control" %>
+      </div>
+    </div>
   </div>
 
   <div class="actions">

--- a/app/views/virtual_samples/_form.html.erb
+++ b/app/views/virtual_samples/_form.html.erb
@@ -22,9 +22,27 @@
 
   <div class="col-sm-4">
     <div class="form-group row">
+      <%= form.label :about_file, "Archivo Tecnico", :class => "col-sm-6 col-form-label" %>
+      <div class="col-sm-6">
+        <%= form.file_field :about_file %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-sm-4">
+    <div class="form-group row">
       <%= form.label :video_link, "Link", :class => "col-sm-6 col-form-label" %>
       <div class="col-sm-6">
         <%= form.text_field :video_link, min:0, max: 2, :class => "form-control" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-sm-4">
+    <div class="form-group row">
+      <%= form.label :images, "Imagenes adicionales", :class => "col-sm-6 col-form-label" %>
+      <div class="col-sm-6">
+        <%= form.file_field :images, multiple: true %>
       </div>
     </div>
   </div>

--- a/app/views/virtual_samples/show.html.erb
+++ b/app/views/virtual_samples/show.html.erb
@@ -20,8 +20,8 @@
 
   <div class='sample-description row'>
     <div class='col-4'> <%= video_tag('', controls: true, class: 'media') %> </div>
-    <div class='col-3'> <%= image_tag('babyyoda.png', class: 'media') %> </div>
-    <div class='col-3'> <%= image_tag('babyyoda.png', class: 'media') %> </div>
+    <div class='col-3'> <%= image_tag(@virtual_sample.images.first, width: '100%') %> </div>
+    <div class='col-3'> <%= image_tag(@virtual_sample.images.last, width: '100%') %> </div>
     <div class='col-2'> <button class='btn bottom-right'> Comentar </button> </div>
   </div>
 </div>

--- a/app/views/virtual_samples/show.html.erb
+++ b/app/views/virtual_samples/show.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class='sample-description row'>
-    <div class='col-3'> <%= image_tag('babyyoda.png', width: '100%') %> </div>
+    <div class='col-3'> <%= image_tag(@virtual_sample.icon_image, width: '100%') %> </div>
     <div class='col-9'>
       <div class='sample-buttons'>
         <span> <%= @project.project_detail.category %> </span>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :test
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/db/migrate/20210405080952_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210405080952_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_222810) do
+ActiveRecord::Schema.define(version: 2021_04_05_080952) do
 
   create_table "abstracts", force: :cascade do |t|
     t.text "problem"
@@ -22,6 +22,27 @@ ActiveRecord::Schema.define(version: 2021_03_18_222810) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["project_id"], name: "index_abstracts_on_project_id"
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "administrators", force: :cascade do |t|
@@ -240,6 +261,7 @@ ActiveRecord::Schema.define(version: 2021_03_18_222810) do
   end
 
   add_foreign_key "abstracts", "projects"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "collaborators", "projects"
   add_foreign_key "committee_evaluations", "projects"
   add_foreign_key "judge_evaluations", "judges"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,33 +48,50 @@ ProjectArea.create(name: "Quimica-Bioquimica")
 ProjectArea.create(name: "Sistemas Embebidos")
 ProjectArea.create(name: "Software")
 
-
-# Admin
-Administrator.create()
-
 #Base Categories:
 ProjectCategory.create(name: "Desarrollo de Prototipo Físico")
 ProjectCategory.create(name: "Desarrollo de Prototipo de Software")
 ProjectCategory.create(name: "Investigacion y Desarrollo de Propuestas de Mejora")
 ProjectCategory.create(name: "Productos o Servicios para Emprendimiento de Base Tecnológica")
 
-# User
-email = "luis@tec.mx"
-password = "123123"
-first_name = "Luis"
-last_name = "Gonzalez"
-userable_id = 1
-userable_type = "Professor"
-edition_id = 1
-institution_id = 1
-User.create(email: email, password: password, first_name: first_name, last_name: last_name, userable_id: userable_id, userable_type: userable_type, edition_id: edition_id, institution_id: institution_id)
+# Users
+userable = Administrator.create()
+User.create(
+    email: "juan@tec.mx",
+    password: "123123",
+    first_name: "Juan",
+    last_name: "Hinojosa",
+    userable_id: userable.id,
+    userable_type: "Administrator",
+    edition_id: 1,
+    institution_id: 1
+)
 
-email = "juan@tec.mx"
-password = "123123"
-first_name = "Juan"
-last_name = "Hinojosa"
-userable_id = 1
-userable_type = "Administrator"
-edition_id = 1
-institution_id = 1
-User.create(email: email, password: password, first_name: first_name, last_name: last_name, userable_id: userable_id, userable_type: userable_type, edition_id: edition_id, institution_id: institution_id)
+userable = Professor.create(
+    department: "ITC"
+)
+User.create(
+    email: "luis@tec.mx", 
+    password: "123123",
+    first_name: "Luis",
+    last_name: "Gonzalez",
+    userable_id: userable.id,
+    userable_type: "Professor",
+    edition_id: 1,
+    institution_id: 1,
+)
+
+userable = Student.create(
+    major: "ITC",
+    student_code: "A01234567"
+)
+User.create(
+    email: "pepe@tec.mx", 
+    password: "123123",
+    first_name: "Pepe",
+    last_name: "Garza",
+    userable_id: userable.id,
+    userable_type: "Student",
+    edition_id: 1,
+    institution_id: 1,
+)


### PR DESCRIPTION
Enable IconImage, TechnicalFile & and OtherImages upload to a project's VirtualSample. Front-end styling left almost untouched, needs work. Current setup should supports AWS, GoogleCloud or Azure. Given, this would require minimal editing once a service is chosen (adding/editing credentials).

![Screen Shot 2021-04-05 at 3 57 52 AM](https://user-images.githubusercontent.com/5950654/113558856-067f4780-95c6-11eb-8cf2-578e48555518.png)
![Screen Shot 2021-04-05 at 4 12 24 AM](https://user-images.githubusercontent.com/5950654/113558875-0c752880-95c6-11eb-9117-1df12deff5bb.png)
