### PR TITLE
Update virtual samples

### DIFF
--- a/app/assets/stylesheets/virtual_samples.scss
+++ b/app/assets/stylesheets/virtual_samples.scss
@@ -22,7 +22,8 @@
   font-size: 12px;
   text-align: left;
 
-  button {
+  button, .link-btn {
+    margin-top: 5px;
     background-color: rgba(4, 49, 133, 0.8);
     color: white;
 
@@ -63,8 +64,22 @@
     border-color: rgba(4, 49, 133, 0.8) !important;
   }
 }
-/* Comment Section */
 
+/* Image Carousel */
+
+.carousel {
+  width: 100%;
+  background-color: rgb(242, 240, 240);
+}
+
+.carousel-item img {
+  width: auto !important;
+  height: 400px;
+  max-height: 400px;
+  margin: auto;
+}
+
+/* Comment Section */
 small {
   font-weight: 400;
   line-height: 1;

--- a/app/controllers/virtual_samples_controller.rb
+++ b/app/controllers/virtual_samples_controller.rb
@@ -50,6 +50,9 @@ class VirtualSamplesController < ApplicationController
   # PATCH/PUT /virtual_samples/1.json
   def update
     respond_to do |format|
+      if params[:virtual_sample][:images].present?
+        @virtual_sample.images.purge
+      end
       if @virtual_sample.update(virtual_sample_params)
         format.html { redirect_to project_virtual_sample_path, notice: 'Virtual sample was successfully updated.' }
         format.json { render :show, status: :ok, location: @virtual_sample }
@@ -78,7 +81,7 @@ class VirtualSamplesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def virtual_sample_params
-      params.require(:virtual_sample).permit(:project_id, :video_link, :icon_image, :about_file, :video_file)
+      params.require(:virtual_sample).permit(:project_id, :video_link, :icon_image, :about_file, :video_file, images: [])
     end
 
     def get_project

--- a/app/views/virtual_samples/show.html.erb
+++ b/app/views/virtual_samples/show.html.erb
@@ -1,30 +1,47 @@
 <div class='content'>
   <div class='sample-header'>
     <h3><%= @project.project_detail.name %></h3>
-    <%= link_to 'Back', virtual_samples_path, :class => 'btn btn-light float-left' %>
+    <%= link_to 'Back', virtual_samples_path, :class => 'btn btn-light float-left'%>
   </div>
 
   <div class='sample-description row'>
-    <div class='col-3'> <%= image_tag(@virtual_sample.icon_image, width: '100%') rescue show_image %> </div>
+    <div class='col-3'>
+      <%= image_tag(@virtual_sample.icon_image, width: '100%') rescue show_image %>
+      <%= link_to 'Archivo técnico', rails_blob_path(@virtual_sample.about_file, disposition: :attachment), :class => 'link-btn btn' %>
+    </div>
     <div class='col-9'>
       <div class='sample-buttons'>
         <span> <%= @project.project_detail.category %> </span>
         <span> <%= @project.project_detail.type_of %> </span>
-        <button class="btn float-right"> Ver archivo técnico </button>
       </div>
       <div class= "description" style="height: 180px;"> <p> <%= @project.project_detail.description %> </p> </div>
     </div>
   </div>
 
   <div class='sample-description row'>
-
     <% if @virtual_sample.video_file.attached? %>
-      <div class='col-4'>
-        <%= video_tag url_for(@virtual_sample.video_file), controls: true, class: 'media' %>
-      </div>
+      <%= video_tag url_for(@virtual_sample.video_file), controls: true, class: 'media' %>
     <% end %>
-    <div class='col-3'> <%= image_tag(@virtual_sample.images.first, width: '100%') rescue show_image %> </div>
-    <div class='col-3'> <%= image_tag(@virtual_sample.images.last, width: '100%') rescue show_image %> </div>
+  </div>
+
+  <div class='sample-description row'>
+    <div id="carouselControls" class="carousel slide" data-ride="carousel">
+      <div class="carousel-inner">
+        <% @virtual_sample.images.each_with_index do |image, i| %>
+          <div class="carousel-item <%= 'active' if i == 0 %>">
+            <img class="d-block w-100" src= <%= url_for(image) %> alt="Imagen <%= i + 1%>">
+          </div>
+        <% end %>
+      </div>
+      <a class="carousel-control-prev" href="#carouselControls" role="button" data-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="sr-only">Previous</span>
+      </a>
+      <a class="carousel-control-next" href="#carouselControls" role="button" data-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="sr-only">Next</span>
+      </a>
+    </div>
   </div>
 
   <!-- TODO remover esta "form" local y utilizar la propia del directorio "comments" -->


### PR DESCRIPTION
- Add functionality to download pdf file from virtual sample
- Add image carousel
- Updated styling to fit carousel, NOTE: could not place image carousel beside video in same row, boostrap carousel styling broke everything, needs fix
- Fix images not updating for a virtual sample

![Screen Shot 2021-05-19 at 6 31 37 AM](https://user-images.githubusercontent.com/5950654/118805773-ef41a400-b86b-11eb-90e2-cff0abdbdd7e.png)
![Screen Shot 2021-05-19 at 6 31 48 AM](https://user-images.githubusercontent.com/5950654/118805793-f2d52b00-b86b-11eb-858a-4b274df074f5.png)

